### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hacs-validate.yml
+++ b/.github/workflows/hacs-validate.yml
@@ -1,4 +1,6 @@
 name: hacs-validate
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CrunkA3/ha_kostal_plenticore_modbus/security/code-scanning/2](https://github.com/CrunkA3/ha_kostal_plenticore_modbus/security/code-scanning/2)

To fix this problem, an explicit `permissions` block should be added to the workflow to restrict the permissions granted to the GITHUB_TOKEN. The standard minimal starting point for most workflows is to set `contents: read`, which allows actions to read repository contents but not write or modify them. Unless any validation or checkout step needs additional privileges (which they do not in this case), this is sufficient. The permissions block should be placed at the root of the workflow YAML, right beneath the workflow name, so it applies to all jobs unless overridden. No changes need to be made to the individual job steps. No imports or other changes outside the shown YAML snippet are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
