### PR TITLE
Sensor and Register Enhancements

### DIFF
--- a/custom_components/kostal_plenticore_modubs/coordinator.py
+++ b/custom_components/kostal_plenticore_modubs/coordinator.py
@@ -89,7 +89,7 @@ class InverterCoordinator(DataUpdateCoordinator):
             if not result.isError():
                 data["registers"][address : address + count] = result.registers
             else:
-                _LOGGER.error("Error reading registers")
+                _LOGGER.error("Error reading registers: addr=%s count=%s", address, count)
 
         try:
             connection = await client.connect()
@@ -97,7 +97,7 @@ class InverterCoordinator(DataUpdateCoordinator):
             if connection:
                 # read Registers
                 await read_holding_registers(98, 124)
-                await read_holding_registers(221, 124)
+                await read_holding_registers(222, 124)
 
                 # read Registers (Battery)
                 await read_holding_registers(512, 18)
@@ -132,7 +132,7 @@ class InverterCoordinator(DataUpdateCoordinator):
 
     async def async_set_min_soc(self, value: float) -> None:
         """set minimum soc"""
-        _LOGGER.warn("InverterCoordinator async_set_min_soc")
+        _LOGGER.warning("InverterCoordinator async_set_min_soc")
 
         client = AsyncModbusTcpClient(
             self._ip_address, port=1502

--- a/custom_components/kostal_plenticore_modubs/register_info.py
+++ b/custom_components/kostal_plenticore_modubs/register_info.py
@@ -118,5 +118,7 @@ REGISTERS: list[RegisterInfo] = [
     RegisterInfo(320, "total_yield", " Total yield", "Wh", "Float", "mdi:flash", "energy", 0, SensorStateClass.TOTAL_INCREASING),
     RegisterInfo(322, "daily_yield", " Daily yield", "Wh", "Float", "mdi:flash", "energy", 0, SensorStateClass.TOTAL_INCREASING),
     RegisterInfo(324, "yearly_yield", " Yearly yield", "Wh", "Float", "mdi:flash", "energy", 0, SensorStateClass.TOTAL_INCREASING),
-    RegisterInfo(326, "monthly_yield", " Monthly yield", "Wh", "Float", "mdi:flash", "energy", 0, SensorStateClass.TOTAL_INCREASING)
+    RegisterInfo(326, "monthly_yield", " Monthly yield", "Wh", "Float", "mdi:flash", "energy", 0, SensorStateClass.TOTAL_INCREASING),
+    RegisterInfo(1025, "power_scale_factor", "Power Scale Factor", None, "S16", "mdi:function-variant", None, 0),
+    RegisterInfo(1068, "battery_work_capacity_sensor", "Battery work capacity", "Wh", "Float", "mdi:battery", "energy_storage", 0)
 ]

--- a/custom_components/kostal_plenticore_modubs/sensor.py
+++ b/custom_components/kostal_plenticore_modubs/sensor.py
@@ -44,8 +44,6 @@ async def async_setup_entry(hass, entry, async_add_entities):
     sensors = [
         InverterStateSensor(inverter_coordinator, ip_address, 56),
         ControllerTemperatureSensor(inverter_coordinator, ip_address, 98),
-        BatteryWorkCapacitySensor(inverter_coordinator, ip_address, 1068),
-        PowerScaleFactorSensor(inverter_coordinator, ip_address, 1025),
         MaxChargePowerSensor(inverter_coordinator, ip_address, 1076),
         MaxDischargePowerSensor(inverter_coordinator, ip_address, 1078),
         CurrentDcSensor(inverter_coordinator, ip_address, 1, 258),
@@ -99,10 +97,12 @@ class KostalSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def name(self):
+        """Return the name of the sensor."""
         return self._name
 
     @property
     def unique_id(self):
+        """Return the unique ID of the sensor."""
         return self._unique_id
 
     @property
@@ -189,22 +189,6 @@ class KostalUInt32Sensor(KostalSensor):
 
 
 
-class BatteryWorkCapacitySensor(KostalFloat32Sensor):
-    """Battery work capacity sensor."""
-
-    def __init__(self, coordinator, ip_address, register_address):
-        super().__init__(coordinator, ip_address, register_address, "battery_work_capacity_sensor", "Battery work capacity", "mdi:battery", "energy_storage", "Wh", 0)
-
-
-
-class PowerScaleFactorSensor(KostalInt16Sensor):
-    """ Power Scale Factor sensor."""
-
-    def __init__(self, coordinator, ip_address, register_address):
-        super().__init__(coordinator, ip_address, register_address, "power_scale_factor", "Power Scale Factor", "mdi:function-variant", None, None, 0)
-
-
-
 class MaxChargePowerSensor(KostalFloat32Sensor):
     """Battery Maximum charge power limit sensor."""
 
@@ -216,7 +200,7 @@ class MaxDischargePowerSensor(KostalFloat32Sensor):
     """Battery Maximum discharge power limit sensor."""
 
     def __init__(self, coordinator, ip_address, register_address):
-        super().__init__(coordinator, ip_address, register_address, f"max_discharge_power_sensor", "Maximum Discharge Power", "mdi:battery-charging-10", "power", "W", 0)
+        super().__init__(coordinator, ip_address, register_address, "max_discharge_power_sensor", "Maximum Discharge Power", "mdi:battery-charging-10", "power", "W", 0)
 
 
 class CurrentDcSensor(KostalFloat32Sensor):
@@ -283,16 +267,18 @@ class InverterStateSensor(CoordinatorEntity, SensorEntity):
         self._register_address = register_address
         self._state = None
 
-        self._name = f"Inverter State"
+        self._name = "Inverter State"
         self._unique_id = f"inverter_state_sensor_{ip_address.replace('.', '_')}"
         self._device_id = f"{NAME}_{ip_address.replace('.', '_')}"
 
     @property
     def name(self):
+        """Return the name of the sensor."""
         return self._name
 
     @property
     def unique_id(self):
+        """Return the unique ID of the sensor."""
         return self._unique_id
 
     @property
@@ -307,6 +293,7 @@ class InverterStateSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def state(self):
+        """Return the state of the sensor."""
         inverter_state = self.coordinator.data["inverter_state"]
         return self._options_enum[inverter_state]
 
@@ -323,4 +310,5 @@ class InverterStateSensor(CoordinatorEntity, SensorEntity):
 
     @property
     def options(self):
+        """Return the list of available options."""
         return list(self._options_enum)


### PR DESCRIPTION
This pull request enhances the Kostal Plenticore Modbus integration by improving sensor type support, adding new register definitions, and making several code quality improvements. The main changes include support for 16-bit and 32-bit signed/unsigned sensors, improved logging, and the addition of new registers for battery work capacity and power scale factor.

**Sensor and Register Enhancements:**

* Added support for `S16`, `U32`, and `S32` sensor types by introducing `KostalInt16Sensor`, `KostalUInt32Sensor`, and `KostalInt32Sensor` classes, and updating the entity setup logic to instantiate these sensors based on register type. (`custom_components/kostal_plenticore_modubs/sensor.py`, `custom_components/kostal_plenticore_modubs/coordinator.py`) [[1]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57R64-R69) [[2]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57L154-L166) [[3]](diffhunk://#diff-766279161e07a33a5891444697ac583d67634934f4f9e146270b8b8539a08c9fR233-R261)
* Added new register definitions for `power_scale_factor` and `battery_work_capacity_sensor` to the register info list. (`custom_components/kostal_plenticore_modubs/register_info.py`)

**Logging and Error Handling:**

* Improved error logging for register read failures to include address and count, and corrected logging level usage (`warning` instead of deprecated `warn`). (`custom_components/kostal_plenticore_modubs/coordinator.py`) [[1]](diffhunk://#diff-766279161e07a33a5891444697ac583d67634934f4f9e146270b8b8539a08c9fL92-R100) [[2]](diffhunk://#diff-766279161e07a33a5891444697ac583d67634934f4f9e146270b8b8539a08c9fL135-R135)

**Code Quality and Readability:**

* Added docstrings to property getters in both `register_info.py` and `sensor.py` for better code clarity and maintainability. [[1]](diffhunk://#diff-a31a8fbc5d48ce8e38abd659a14af08d3528fa0ccd23a154d193726ff7840708R38-R56) [[2]](diffhunk://#diff-a31a8fbc5d48ce8e38abd659a14af08d3528fa0ccd23a154d193726ff7840708R79-R85) [[3]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57R100-R105) [[4]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57L248-R281) [[5]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57R296) [[6]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57R313)
* Removed duplicate assignment of `self._type` and cleaned up unused or redundant sensor classes. (`custom_components/kostal_plenticore_modubs/register_info.py`, `custom_components/kostal_plenticore_modubs/sensor.py`) [[1]](diffhunk://#diff-a31a8fbc5d48ce8e38abd659a14af08d3528fa0ccd23a154d193726ff7840708L29) [[2]](diffhunk://#diff-dcbf8559e717b3ed1d90cedce7e7b0974e6382623baf85c9d49e430462ddef57L154-L166)

**Bug Fixes:**

* Corrected the register address in a Modbus read operation from 221 to 222. (`custom_components/kostal_plenticore_modubs/coordinator.py`)
* Fixed the use of a literal string for the name of the inverter state sensor. (`custom_components/kostal_plenticore_modubs/sensor.py`)

These changes collectively improve the robustness, maintainability, and feature set of the integration.