### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,4 +1,6 @@
 name: HACS Action
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/CrunkA3/ha_kostal_plenticore_modbus/security/code-scanning/1](https://github.com/CrunkA3/ha_kostal_plenticore_modbus/security/code-scanning/1)

In general, this problem is fixed by adding an explicit `permissions:` block to the workflow (at the root or per job) restricting the `GITHUB_TOKEN` to the minimum required scopes (typically `contents: read` as a safe baseline). For workflows that only need to read repository contents and metadata, `permissions: contents: read` is usually sufficient.

For this specific workflow file `.github/workflows/validate.yml`, the simplest and least intrusive fix is to add a top‑level `permissions:` block after the `name:` declaration, before the `on:` section. This will apply to all jobs in the workflow (here only the `hacs` job) and limit `GITHUB_TOKEN` to read‑only repository contents. Unless you know this workflow needs to write to issues, PRs, or contents, `contents: read` is the safest default. No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
